### PR TITLE
Added SunTrust and Navy Federal CU

### DIFF
--- a/banks/us/navyfederal.json
+++ b/banks/us/navyfederal.json
@@ -1,0 +1,15 @@
+{
+    "name": "navyfederal",
+    "country": "us",
+    "localTitle": "Navy Federal Credit Union",
+    "engTitle": "Navy Federal Credit Union",
+    "url": "https://www.navyfederal.org",
+    "color": "#0f4471",
+    "prefixes": [
+      406041,
+      400022,
+      406095,
+      406315,
+      403216
+    ]
+  }

--- a/banks/us/suntrust.json
+++ b/banks/us/suntrust.json
@@ -1,0 +1,20 @@
+{
+  "name": "suntrust",
+  "country": "us",
+  "localTitle": "SunTrust",
+  "engTitle": "SunTrust",
+  "url": "https://www.suntrust.com",
+  "color": "#ef7622",
+  "prefixes": [
+    553693,
+    546540,
+    519667,
+    519669,
+    442505,
+    553694,
+    552393,
+    557621,
+    451805,
+    486560
+  ]
+}


### PR DESCRIPTION
The list of BINs I found for SunTrust may have only been for their Debit Cards (I added this so that MY debit card would be covered). Navy Federal should be a complete set of BINs.

I'm thinking this is the list of SunTrust credit card bins (I DID NOT add this list):
https://binlists.com/suntrust-bank

You can add them if you'd like. I see it says "and 42 more" at the bottom, but it doesn't have a link to them. I didn't want to spend all that time adding them just to miss a bunch. 

This is the list that my BIN was under and that I added: https://binlists.com/suntrust