### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
+cache: yarn
 node_js:
+  - stable
   - "6"
-  - "5"
   - "4"


### PR DESCRIPTION
1. `cache: yarn` will speed up yarn-based projects.
2. Node.js 5 is not supported anymore.
3. `stable` will be always the last Node.js (current is 8.x), so you will not need to update it manually.