### PR TITLE
Updated name

### DIFF
--- a/banks/ru/sberbank.json
+++ b/banks/ru/sberbank.json
@@ -1,8 +1,8 @@
 {
   "name": "sberbank",
   "country": "ru",
-  "localTitle": "Сбербанк",
-  "engTitle": "Sberbank",
+  "localTitle": "СберБанк",
+  "engTitle": "SberBank",
   "url": "https://www.sberbank.ru",
   "color": "#309c0b",
   "prefixes": [


### PR DESCRIPTION
As a result of the rebrending on September 24, 2020, now each service of PJSC SBERBANK has it's own name, starting with prefix «Sber» (ru - «Сбер») and a capital letter.